### PR TITLE
iidx: fix ASIO bug in Pinky

### DIFF
--- a/patches/LDJ-68a2bd1c_b1c7bc.json
+++ b/patches/LDJ-68a2bd1c_b1c7bc.json
@@ -544,6 +544,20 @@
         ]
     },
     {
+        "name": "ASIO Compatibility Fix",
+        "description": "Fixes bug in bm2dx that causes incompatibility with many ASIO drivers.",
+        "gameCode": "LDJ",
+        "type": "memory",
+        "patches": [
+            {
+                "offset": 4692394,
+                "dllName": "bm2dx.dll",
+                "dataDisabled": "FF5008488B4B08488B01FF5008",
+                "dataEnabled":  "FF5008488B4B08488B01909090"
+            }
+        ]
+    },
+    {
         "name": "Force Max V-Discs",
         "description": "Forces your V-Discs to be maxed out.",
         "caution": "May(?) cause issues on online networks, use at your own risk.",


### PR DESCRIPTION
*They* introduced a bug in bm2dx's audio engine in iidx32. This patch fixes it, so that it's in line with previous versions of iidx.

Essentially, the audio engine (for no reason) calls ASIO `AddRef` twice in a row. This patch removes the second `AddRef` call so that we don't end up with a reference leak, which causes many ASIO implementation to be unhappy when another instance is initialized while a dangling reference remains for the old instance.

### Patch contents

```
0:  ff 50 08                call   QWORD PTR [rax+0x8]
3:  48 8b 4b 08             mov    rcx,QWORD PTR [rbx+0x8]
7:  48 8b 01                mov    rax,QWORD PTR [rcx]
a:  ff 50 08                call   QWORD PTR [rax+0x8]
```

The call instructions call AddRef function of the ASIO driver. This patch nop's out the last instruction.

### How found:

Set breakpoint on 

```FlexASIO!ATL::CComObject<flexasio::`anonymous namespace'::CFlexASIO>::AddRef```

and watch it get called multiple times, adding too many ref counts.

### Tested on:

* FlexASIO 1.9 (resolves the hang)
* Yamaha Steinberg USB ASIO (by another user)
* Sanity check on newer FlexASIO, Xonar AE, Realtek ASIO for regression (no impact).

Will also try to push an update for the patch finder when I have time...